### PR TITLE
Channel: Fix bug in map()

### DIFF
--- a/src/main/scala/org/widok/Channel.scala
+++ b/src/main/scala/org/widok/Channel.scala
@@ -355,8 +355,10 @@ case class Aggregate[T]() {
 
     attach(new Aggregate.Observer[T] {
       def append(ch: Channel[T]) {
+        val target = agg.append()
+        
         ch.attach(value => {
-          val target = agg.append(f(value))
+          target := f(value)
           map += (ch -> target)
         })
       }

--- a/src/test/scala/org/widok/ChannelTest.scala
+++ b/src/test/scala/org/widok/ChannelTest.scala
@@ -364,8 +364,11 @@ object ChannelTest extends JasmineTest {
       val one = agg.append(1)
       expect(sum).toBe(100)
 
+      one := 2
+      expect(sum).toBe(200)
+
       agg.append(2)
-      expect(sum).toBe(300)
+      expect(sum).toBe(400)
 
       agg.remove(one)
       expect(sum).toBe(200)


### PR DESCRIPTION
Do not append a new element each time the channel produces a value.
