### PR TITLE
add missing imports in build.scala, and use `crossProject` to simplify code

### DIFF
--- a/docs/chapters/04-build-process.md
+++ b/docs/chapters/04-build-process.md
@@ -203,13 +203,13 @@ Scala.js provides a simple infrastructure to having separate sub-projects for Ja
 Such projects are called *cross-projects* in Scala.js. You can find more information in the [official documentation](http://www.scala-js.org/doc/sbt/cross-building.html).
 
 ```scala
-import org.scalajs.sbtplugin.cross.CrossProject
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+import sbt.Keys._
+import sbt._
 
 object Build extends sbt.Build {
-  lazy val crossProject =
-    CrossProject(
-      "server", "client", file("."), CrossType.Full
-    )
+  lazy val myCrossProject =
+    crossProject.in(file("."))
     .settings(
       /* Shared settings */
     )
@@ -220,8 +220,8 @@ object Build extends sbt.Build {
       /* JVM settings */
     )
 
-  lazy val js = crossProject.js
-  lazy val jvm = crossProject.jvm
+  lazy val js = myCrossProject.js
+  lazy val jvm = myCrossProject.jvm
 }
 ```
 


### PR DESCRIPTION
```scala
CrossProject(
      "server", "client", file("."), CrossType.Full
)
```

The "server/client" confused me for a while (I'm not quite familiar with `sbt`), and I found in the [scalajs-doc](http://www.scala-js.org/doc/sbt/cross-building.html), it uses the `crossProject` builder in demo, so I changed it. (Not sure if it's correct though `:)` )
