### PR TITLE
Added a ResolvablePage trait

### DIFF
--- a/js/src/main/scala/org/widok/Page.scala
+++ b/js/src/main/scala/org/widok/Page.scala
@@ -2,6 +2,8 @@ package org.widok
 
 import org.scalajs.dom
 
+import scala.concurrent.Future
+
 trait BasePage {
   val document = Document
 
@@ -20,14 +22,22 @@ trait BasePage {
     }
   }
 
-  def destroy() { }
+  def destroy() {}
 }
 
 trait Page extends BasePage {
-  def ready(route: InstantiatedRoute)
+  def ready(route: InstantiatedRoute) {}
 
   def render(route: InstantiatedRoute) {
     render()
     ready(route)
   }
+}
+
+trait ResolvablePage[A] extends Page {
+
+  val resolved = Opt[A]()
+
+  def resolve(args: Map[String, String]): Future[A]
+
 }


### PR DESCRIPTION
If the router encounters a ResolvablePage it will call the resolve method and wait for the returned Future to complete successfully before the route is executed and the Page is rendered. This can be used to pre-fetch data from the server and render the whole page at once.

I have used this like in the following example:

```scala
case class HomePage() extends GBBasePage with ResolvablePage[Seq[Chapter]] {

  lazy val chapters = Buffer[Chapter](resolved.get: _*)

  override def body: Widget[_] = div(
    Main.user match {
      case None => p("Hello anonymous!")
      case Some(u) => home
    }
  )

  def home = div(
    div(
      chapters.map(c =>
        a(c.title, a(span("86").css("new", "badge")).url(s"#/chapters/${c.id.get}/test")).url(s"#/chapters/${c.id.get}").css("collection-item"))
    ).css("collection"),
    a(i().css("mdi-content-add")).url("#/chapters/new").css("btn-floating", "btn-large", "waves-effect", "waves-light", "red", "right")
  ).css("clearfix")

  override def resolve(args: Map[String, String]): Future[Seq[Chapter]] =
    Main.user.map(_ => ServerOpts.findChapters()).getOrElse(Future.successful(Seq.empty))
}
```