### PR TITLE
Opt: Inherit from ReadChannel[Option[T]] as per issue #75

### DIFF
--- a/js/src/main/scala/org/widok.scala
+++ b/js/src/main/scala/org/widok.scala
@@ -68,6 +68,12 @@ package object widok {
     ch
   }
 
+  implicit class PimpedOpt[T](opt: Opt[T]) {
+    def :=(t: T) {
+      opt := Some(t)
+    }
+  }
+
   /** Short aliases for HTML tags
     * See also http://stackoverflow.com/questions/21831497/type-aliasing-a-case-class-in-scala-2-10
     */

--- a/js/src/main/scala/org/widok/Router.scala
+++ b/js/src/main/scala/org/widok/Router.scala
@@ -119,10 +119,10 @@ case class Router(unorderedRoutes: Set[Route],
   def render(nextPage: Page, route: InstantiatedRoute) {
     nextPage.render(route).onComplete {
       case Success(r) =>
-        currentPage.toOption.foreach(_.destroy())
+        currentPage.get.foreach(_.destroy())
         PageContainer.replace(r)
         nextPage.ready(PageContainer.node)
-        currentPage := nextPage
+        currentPage := Some(nextPage)
 
       case Failure(t) => error(s"Failed to load page: $t")
     }

--- a/js/src/main/scala/org/widok/Widget.scala
+++ b/js/src/main/scala/org/widok/Widget.scala
@@ -168,7 +168,7 @@ object Widget {
 object DOMChannel {
   def variable[T](set: T => Unit) = {
     val opt = Opt[T]()
-    opt.attach(set)
+    opt.values.attach(set)
     opt
   }
 
@@ -378,9 +378,9 @@ trait Widget[T] extends Node { self: T =>
 
   def focus(): T = { rendered.focus(); this }
 
-  def id(value: String): T = { nodeId := value; self }
+  def id(value: String): T = { nodeId := Some(value); self }
 
-  def id(value: ReadChannel[String]): T = { nodeId.subscribe(value); self }
+  def id(value: ReadChannel[String]): T = { nodeId.subscribe(value.map(Some(_))); self }
 
   def css(cssTags: String*): T = {
     cssTags.filterNot(className.contains$).foreach(className.insert)
@@ -414,9 +414,9 @@ trait Widget[T] extends Node { self: T =>
   }
 
   def attributeOpt(key: String, value: PartialChannel[String]): T = {
-    value.values.attach {
+    value.attach {
+      case None    => attributes.removeIfExists(key)
       case Some(v) => attributes.insertOrUpdate(key, v)
-      case None => attributes.removeIfExists(key)
     }
 
     self
@@ -428,26 +428,26 @@ trait Widget[T] extends Node { self: T =>
   def title(value: String): T = attribute("title", value)
   def title(value: ReadChannel[String]): T = attribute("title", value)
 
-  def cursor(cursor: HTML.Cursor): T = { style.cursor := cursor; self }
+  def cursor(cursor: HTML.Cursor): T = { style.cursor := Some(cursor); self }
   def cursor(cursor: ReadChannel[HTML.Cursor]): T = {
-    style.cursor.subscribe(cursor)
+    style.cursor.subscribe(cursor.map(Some(_)))
     self
   }
 
-  def height(height: Length): T = { style.height := height; self }
+  def height(height: Length): T = { style.height := Some(height); self }
   def height(height: ReadChannel[Length]): T = {
-    style.height.subscribe(height)
+    style.height.subscribe(height.map(Some(_)))
     self
   }
 
-  def width(width: Length): T = { style.width := width; self }
+  def width(width: Length): T = { style.width := Some(width); self }
   def width(width: ReadChannel[Length]): T = {
-    style.width.subscribe(width)
+    style.width.subscribe(width.map(Some(_)))
     self
   }
 
   def show(value: Boolean): T = {
-    style.display := (if (value) "" else "none")
+    style.display := Some(if (value) "" else "none")
     self
   }
 
@@ -457,7 +457,7 @@ trait Widget[T] extends Node { self: T =>
   }
 
   def hide(value: Boolean): T = {
-    style.display := (if (value) "none" else "")
+    style.display := Some(if (value) "none" else "")
     self
   }
 
@@ -467,7 +467,7 @@ trait Widget[T] extends Node { self: T =>
   }
 
   def visible(value: Boolean): T = {
-    style.visibility := (if (value) "visible" else "hidden")
+    style.visibility := Some(if (value) "visible" else "hidden")
     self
   }
 
@@ -477,7 +477,7 @@ trait Widget[T] extends Node { self: T =>
   }
 
   def invisible(value: Boolean): T = {
-    style.visibility := (if (value) "hidden" else "visible")
+    style.visibility := Some(if (value) "hidden" else "visible")
     self
   }
 

--- a/js/src/main/scala/org/widok/bindings/Bootstrap/ModalBuilder.scala
+++ b/js/src/main/scala/org/widok/bindings/Bootstrap/ModalBuilder.scala
@@ -33,7 +33,7 @@ case class ModalBuilder(contents: Modal.ContentElement*)
   /* .show(shown) wouldn't work here because Bootstrap uses
    * `style.display = none` in its stylesheet.
    */
-  modal.style.display << shown.map(if (_) "block" else "none")
+  modal.style.display << shown.map(shown => Some(if (shown) "block" else "none"))
 
   val ch = shown.tail.distinct.attach(
     if (_) {

--- a/js/src/main/scala/org/widok/bindings/Bootstrap/Typeahead.scala
+++ b/js/src/main/scala/org/widok/bindings/Bootstrap/Typeahead.scala
@@ -68,22 +68,22 @@ case class Typeahead[A](
 
   private def prev() {
     if (results.get.nonEmpty) {
-      if (active.isEmpty$) active := Some(results.get.head)
+      if (active.isEmpty$) active := results.get.head
       else {
         val before = results.beforeOption$(active.get.get)
-        if (before.isEmpty) active := Some(results.get.last)
-        else active := Some(before.get)
+        if (before.isEmpty) active := results.get.last
+        else active := before.get
       }
     }
   }
 
   private def next() {
     if (results.get.nonEmpty) {
-      if (active.isEmpty$) active := Some(results.get.head)
+      if (active.isEmpty$) active := results.get.head
       else {
         val after = results.afterOption$(active.get.get)
-        if (after.isEmpty) active := Some(results.get.head)
-        else active := Some(after.get)
+        if (after.isEmpty) active := results.get.head
+        else active := after.get
       }
     }
   }

--- a/js/src/main/scala/org/widok/bindings/Bootstrap/Typeahead.scala
+++ b/js/src/main/scala/org/widok/bindings/Bootstrap/Typeahead.scala
@@ -29,7 +29,7 @@ case class Typeahead[A](
   private val list = ul(
     results.map { case cur @ (id, caption) =>
       li(a(caption).onClick(_ => onSelect(id)))
-        .cssState(active.is(cur), "active")
+        .cssState(active.is(Some(cur)), "active")
     }
   ).css("typeahead", "dropdown-menu")
 
@@ -68,22 +68,22 @@ case class Typeahead[A](
 
   private def prev() {
     if (results.get.nonEmpty) {
-      if (active.isEmpty$) active := results.get.head
+      if (active.isEmpty$) active := Some(results.get.head)
       else {
-        val before = results.beforeOption$(active.get)
-        if (before.isEmpty) active := results.get.last
-        else active := before.get
+        val before = results.beforeOption$(active.get.get)
+        if (before.isEmpty) active := Some(results.get.last)
+        else active := Some(before.get)
       }
     }
   }
 
   private def next() {
     if (results.get.nonEmpty) {
-      if (active.isEmpty$) active := results.get.head
+      if (active.isEmpty$) active := Some(results.get.head)
       else {
-        val after = results.afterOption$(active.get)
-        if (after.isEmpty) active := results.get.head
-        else active := after.get
+        val after = results.afterOption$(active.get.get)
+        if (after.isEmpty) active := Some(results.get.head)
+        else active := Some(after.get)
       }
     }
   }
@@ -92,7 +92,7 @@ case class Typeahead[A](
     handleKeyUp = false
 
     e.keyCode match {
-      case KeyCode.Enter => onSelect(active.get._1)
+      case KeyCode.Enter => onSelect(active.get.get._1)
       case KeyCode.Tab | KeyCode.Escape => close()
       case KeyCode.Up if !e.shiftKey => // left parenthesis if e.shiftKey
         prev()

--- a/js/src/main/scala/org/widok/bindings/Bootstrap/package.scala
+++ b/js/src/main/scala/org/widok/bindings/Bootstrap/package.scala
@@ -645,7 +645,7 @@ package object Bootstrap {
       .foldLeft(Map.empty[ReadChannel[_], ReadChannel[Option[String]]])
     { case (acc, Validation(ch, _)) =>
       acc + (ch -> dirty.flatMap(
-        if (_) invalid.value(ch).values
+        if (_) invalid.value(ch)
         else Var(None)
       ))
     }

--- a/js/src/main/scala/org/widok/validation/Validator.scala
+++ b/js/src/main/scala/org/widok/validation/Validator.scala
@@ -2,29 +2,29 @@ package org.widok.validation
 
 import org.widok.{Buffer, Dict, ReadChannel}
 
-case class Validator(validationSources: Tuple2[ReadChannel[_], Seq[Validation[_]]]*) {
-
+case class Validator(validationSources: (ReadChannel[_], Seq[Validation[_]])*) {
   val validations = Dict[ReadChannel[_], Seq[String]]()
-
   val valid = validations.forall(_.isEmpty).cache(true)
-
   val errors = validations.filter(_.nonEmpty).buffer
 
   def valid(ch: ReadChannel[_]) = errors.value(ch).isEmpty
-
   def invalid(ch: ReadChannel[_]) = errors.value(ch).isDefined
 
   // combines the validation results from several channels
   def combinedErrors(channels: ReadChannel[_]*): Buffer[String] = {
     val result = Buffer[String]()
-    var messagesByChannel = channels.map(key => key -> Seq[String]()).toMap[ReadChannel[_], Seq[String]]
+
+    var messagesByChannel = channels
+      .map(_ -> Seq[String]())
+      .toMap[ReadChannel[_], Seq[String]]
 
     channels.map(errors.value(_).values).foreach { channel =>
       channel.attach { optCh =>
-        messagesByChannel += (channel -> optCh.getOrElse(Seq.empty))
-        result.set(messagesByChannel.values.flatten.toSet.toSeq) // set all unique errors
+        messagesByChannel += (channel -> optCh)
+        result.set(messagesByChannel.values.flatten.toSeq.distinct) // set all unique errors
       }
     }
+
     result
   }
 
@@ -43,6 +43,7 @@ case class Validator(validationSources: Tuple2[ReadChannel[_], Seq[Validation[_]
     validationSources.filterNot(s => validations.keys$.contains(s._1)).foreach {
       case (ch, fv) => ch.flush(validateValue(ch, fv, _))
     }
+
     valid.get
   }
 }

--- a/jvm/src/main/scala/org/widok.scala
+++ b/jvm/src/main/scala/org/widok.scala
@@ -8,4 +8,10 @@ package object widok {
     ch.attach(f)
     ch
   }
+
+  implicit class PimpedOpt[T](opt: Opt[T]) {
+    def :=(t: T) {
+      opt := Some(t)
+    }
+  }
 }

--- a/shared/src/main/scala/org/widok/Dict.scala
+++ b/shared/src/main/scala/org/widok/Dict.scala
@@ -105,8 +105,8 @@ trait DeltaDict[A, B]
     val res = Opt[B]()
 
     changes.attach {
-      case Delta.Insert(`key`, value) => res := value
-      case Delta.Update(`key`, value) => res := value
+      case Delta.Insert(`key`, value) => res := Some(value)
+      case Delta.Update(`key`, value) => res := Some(value)
       case Delta.Remove(`key`) => res.clear()
       case Delta.Clear() if res.nonEmpty$ => res.clear()
       case _ =>

--- a/shared/src/main/scala/org/widok/Var.scala
+++ b/shared/src/main/scala/org/widok/Var.scala
@@ -1,6 +1,9 @@
 package org.widok
 
-sealed class Var[T](private var v: T) extends StateChannel[T] with ChannelDefaultSize[T] {
+sealed class Var[T](private var v: T)
+  extends StateChannel[T]
+  with ChannelDefaultSize[T]
+{
   attach(v = _)
 
   def flush(f: T => Unit) { f(v) }

--- a/shared/src/main/scala/org/widok/reactive/propagate/Produce.scala
+++ b/shared/src/main/scala/org/widok/reactive/propagate/Produce.scala
@@ -1,6 +1,6 @@
 package org.widok.reactive.propagate
 
-trait Channel[T] {
+trait Produce[T] {
   def produce(value: T)
   def :=(value: T) = produce(value)
 }

--- a/shared/src/main/scala/org/widok/reactive/stream/PartialChannel.scala
+++ b/shared/src/main/scala/org/widok/reactive/stream/PartialChannel.scala
@@ -6,6 +6,6 @@ trait PartialChannel[T] {
   /** true if partial channel has a value, false otherwise */
   def isDefined: ReadChannel[Boolean]
 
-  /** Wraps the defined value or undefined state into an [[Option]] instance */
-  def values: ReadChannel[Option[T]]
+  /** Filters out all defined values */
+  def values: ReadChannel[T]
 }

--- a/shared/src/main/scala/org/widok/reactive/stream/RelativeOrder.scala
+++ b/shared/src/main/scala/org/widok/reactive/stream/RelativeOrder.scala
@@ -16,8 +16,8 @@ trait RelativeOrder[T] {
   def after(value: T): ReadChannel[T]
 
   /** @see [[before]] */
-  def beforeOption(value: T): ReadPartialChannel[T]
+  def beforeOption(value: T): ReadChannel[T]
 
   /** @see [[after]] */
-  def afterOption(value: T): ReadPartialChannel[T]
+  def afterOption(value: T): ReadChannel[T]
 }

--- a/shared/src/test/scala/org/widok/BufferSpec.scala
+++ b/shared/src/test/scala/org/widok/BufferSpec.scala
@@ -120,13 +120,13 @@ object BufferSpec extends SimpleTestSuite {
   }
 
   test("headOption") {
-    forallBuf(buffer => (buffer.headOption, buffer.head))
-    forallBuf(buffer => (buffer.headOption.values.partialMap { case Some(v) => v }, buffer.head))
+    forallBuf(buffer => (buffer.headOption.values, buffer.head))
+    forallBuf(buffer => (buffer.headOption.partialMap { case Some(v) => v }, buffer.head))
   }
 
   test("lastOption") {
-    forallBuf(buffer => (buffer.lastOption, buffer.last))
-    forallBuf(buffer => (buffer.lastOption.values.partialMap { case Some(v) => v }, buffer.last))
+    forallBuf(buffer => (buffer.lastOption.values, buffer.last))
+    forallBuf(buffer => (buffer.lastOption.partialMap { case Some(v) => v }, buffer.last))
   }
 
   test("last") {
@@ -142,6 +142,6 @@ object BufferSpec extends SimpleTestSuite {
   }
 
   test("find") {
-    forallBufSeq(buffer => (buffer.find(_ > 1).toBuffer, () => buffer.get.find(_ > 1).toSeq))
+    forallBufSeq(buffer => (buffer.find(_ > 1).values.toBuffer, () => buffer.get.find(_ > 1).toSeq))
   }
 }

--- a/shared/src/test/scala/org/widok/BufferTest.scala
+++ b/shared/src/test/scala/org/widok/BufferTest.scala
@@ -99,7 +99,7 @@ object BufferTest extends SimpleTestSuite {
     x.prepend(5)
     assertEquals(y.get, Seq(5, 1, 2, 3))
 
-    ch := Some(9)
+    ch := 9
     assertEquals(y.get, Seq(5, 9, 1, 2, 3))
   }
 

--- a/shared/src/test/scala/org/widok/BufferTest.scala
+++ b/shared/src/test/scala/org/widok/BufferTest.scala
@@ -24,7 +24,7 @@ object BufferTest extends SimpleTestSuite {
   test("filter().lastOption") {
     val buf = Buffer[Int]()
     val filter = buf.filter(_ > 1)
-    var last = -1
+    var last = Option.empty[Int]
 
     filter.buffer.lastOption.attach(last = _)
 
@@ -32,10 +32,10 @@ object BufferTest extends SimpleTestSuite {
     buf += 2
     buf += 3
 
-    assertEquals(last, 3)
+    assertEquals(last, Some(3))
     buf.remove(buf.get(2))
 
-    assertEquals(last, 2)
+    assertEquals(last, Some(2))
   }
 
   test("size()") {
@@ -84,7 +84,7 @@ object BufferTest extends SimpleTestSuite {
 
   test("flatMapCh()") {
     val x = Buffer(1, 2, 3)
-    val ch: Opt[Int] = Opt(42)
+    val ch = Opt(42)
     val y = x.flatMapCh[Int](value =>
       if (value == 4) ch else Opt(value))
 
@@ -99,7 +99,7 @@ object BufferTest extends SimpleTestSuite {
     x.prepend(5)
     assertEquals(y.get, Seq(5, 1, 2, 3))
 
-    ch := 9
+    ch := Some(9)
     assertEquals(y.get, Seq(5, 9, 1, 2, 3))
   }
 
@@ -120,6 +120,7 @@ object BufferTest extends SimpleTestSuite {
     x ++= add
 
     val y = x.filter(_ <= 3).buffer
+    assertEquals(y.get, Seq(1, 2, 3))
     x.removeAll(y)
 
     assertEquals(x.get, add.get)
@@ -129,7 +130,7 @@ object BufferTest extends SimpleTestSuite {
     val buffer = Buffer(1, 2, 3)
 
     var states = mutable.ArrayBuffer.empty[Int]
-    buffer.find(_ > 1).attach(states += _)
+    buffer.find(_ > 1).values.attach(states += _)
     assertEquals(states, mutable.ArrayBuffer(2))
 
     buffer.remove(2)
@@ -139,7 +140,7 @@ object BufferTest extends SimpleTestSuite {
   test("buffer") {
     val buffer = Buffer(1, 2, 3)
 
-    val states = buffer.find(_ > 1).buffer
+    val states = buffer.find(_ > 1).values.buffer
     assertEquals(states.get, Seq(2))
 
     buffer.remove(2)
@@ -148,7 +149,7 @@ object BufferTest extends SimpleTestSuite {
 
   test("buffer") {
     val buffer = Buffer[Int]()
-    val states = buffer.find(_ > 1).buffer
+    val states = buffer.find(_ > 1).values.buffer
 
     buffer += 1
     buffer += 2

--- a/shared/src/test/scala/org/widok/ChannelSpec.scala
+++ b/shared/src/test/scala/org/widok/ChannelSpec.scala
@@ -25,9 +25,9 @@ object ChannelSpec extends SimpleTestSuite {
   def forallChVal[T](f: (Channel[Int], Int) => (ReadChannel[T], ReadChannel[T])) {
     /* Different channel types may differ in their semantics. */
     val channels = Seq(
-      () => Var[Int](0),
-      () => Opt[Int](0),
-      () => Channel[Int]())
+      () => Var[Int](0)
+    , () => Channel[Int]()
+    )
     val elems = Seq(1, 2, 3)
 
     channels.foreach { fch =>
@@ -101,7 +101,7 @@ object ChannelSpec extends SimpleTestSuite {
   }
 
   test("Opt") {
-    forallCh(ch => (ch.toOpt, ch))
+    forallCh(ch => (ch.toOpt.values, ch))
 
     assertEqualsCh(Opt().isDefined.head, Var(false))
     assertEqualsCh(Opt(42).isDefined.head, Var(true))
@@ -109,7 +109,7 @@ object ChannelSpec extends SimpleTestSuite {
     assertEqualsCh(Opt().isDefined, Opt().nonEmpty)
     assertEqualsCh(Opt(42).isDefined, Opt(42).nonEmpty)
 
-    assertEqualsCh(Opt(42), Var(42))
-    assertEqualsCh(Opt(), Channel())
+    assertEqualsCh(Opt(42).values, Var(42))
+    assertEqualsCh(Opt().values, Channel())
   }
 }

--- a/shared/src/test/scala/org/widok/ChannelTest.scala
+++ b/shared/src/test/scala/org/widok/ChannelTest.scala
@@ -55,27 +55,27 @@ object ChannelTest extends SimpleTestSuite {
 
   test("distinct()") {
     val ch = Opt[Int](0)
-    val ch2 = ch.distinct
+    val ch2 = ch.values.distinct
 
     var sum = 0
     ch2.attach(sum += _)
 
-    ch := 1
-    ch := 1
-    ch := 2
+    ch := Some(1)
+    ch := Some(1)
+    ch := Some(2)
 
     assertEquals(sum, 3)
   }
 
   test("distinct()") {
     val ch = Opt[Int](0)
-    val ch2 = ch.distinct
+    val ch2 = ch.values.distinct
 
     var sum = 0
 
-    ch := 1
-    ch := 1
-    ch := 2
+    ch := Some(1)
+    ch := Some(1)
+    ch := Some(2)
 
     ch2.attach(sum += _)
     assertEquals(sum, 2)
@@ -431,7 +431,7 @@ object ChannelTest extends SimpleTestSuite {
     ch2.attach(sum += _)
 
     map := 1
-    ch := 0
+    ch := Some(0)
 
     map := 5
     assertEquals(sum, 5)
@@ -443,11 +443,11 @@ object ChannelTest extends SimpleTestSuite {
 
     var sum = 0
 
-    ch.attach(sum += _)
+    ch.values.attach(sum += _)
     map.attach(sum += _)
 
-    ch := 0
-    ch := 0
+    ch := Some(0)
+    ch := Some(0)
 
     assertEquals(sum, 84)
   }
@@ -552,25 +552,25 @@ object ChannelTest extends SimpleTestSuite {
     val ch = Channel[Int]()
     val map = ch.partialMap { case 1 => 42 }
 
-    var states = mutable.ArrayBuffer.empty[Option[Int]]
-    map.values.attach(states += _)
+    var states = mutable.ArrayBuffer.empty[Int]
+    map.attach(states += _)
 
     ch := 2
     ch := 3
     ch := 1
     ch := 4
 
-    assertEquals(states, mutable.ArrayBuffer(None, Some(42), None))
+    assertEquals(states, mutable.ArrayBuffer(42))
   }
 
   test("partialMap()") {
     val ch = Buffer[Int](1, 2, 3).buffer
     val map = ch.changes.partialMap { case Buffer.Delta.Insert(_, 2) => 42 }
 
-    var states = mutable.ArrayBuffer.empty[Option[Int]]
-    map.values.attach(states += _)
+    var states = mutable.ArrayBuffer.empty[Int]
+    map.attach(states += _)
 
-    assertEquals(states, mutable.ArrayBuffer(Some(42)))
+    assertEquals(states, mutable.ArrayBuffer(42))
   }
 
   test("Channel()") {

--- a/shared/src/test/scala/org/widok/ChannelTest.scala
+++ b/shared/src/test/scala/org/widok/ChannelTest.scala
@@ -60,9 +60,9 @@ object ChannelTest extends SimpleTestSuite {
     var sum = 0
     ch2.attach(sum += _)
 
-    ch := Some(1)
-    ch := Some(1)
-    ch := Some(2)
+    ch := 1
+    ch := 1
+    ch := 2
 
     assertEquals(sum, 3)
   }
@@ -73,9 +73,9 @@ object ChannelTest extends SimpleTestSuite {
 
     var sum = 0
 
-    ch := Some(1)
-    ch := Some(1)
-    ch := Some(2)
+    ch := 1
+    ch := 1
+    ch := 2
 
     ch2.attach(sum += _)
     assertEquals(sum, 2)
@@ -431,7 +431,7 @@ object ChannelTest extends SimpleTestSuite {
     ch2.attach(sum += _)
 
     map := 1
-    ch := Some(0)
+    ch := 0
 
     map := 5
     assertEquals(sum, 5)
@@ -446,8 +446,8 @@ object ChannelTest extends SimpleTestSuite {
     ch.values.attach(sum += _)
     map.attach(sum += _)
 
-    ch := Some(0)
-    ch := Some(0)
+    ch := 0
+    ch := 0
 
     assertEquals(sum, 84)
   }

--- a/shared/src/test/scala/org/widok/OptTest.scala
+++ b/shared/src/test/scala/org/widok/OptTest.scala
@@ -22,16 +22,16 @@ object OptTest extends SimpleTestSuite {
 
     val ch = Opt(0)
     val x = Channel[String]()
-    val y = ch.flatMap(cur => x.map(_ + cur))
+    val y = ch.values.flatMap(cur => x.map(_ + cur))
 
     y.attach(elems += _)
 
     x := "a"
 
-    ch := 1
+    ch := Some(1)
     x := "b"
 
-    ch := 2
+    ch := Some(2)
     x := "c"
 
     assertEquals(elems, mutable.ArrayBuffer("a0", "b1", "c2"))
@@ -54,8 +54,8 @@ object OptTest extends SimpleTestSuite {
     size.attach(elems += _)
 
     ch.clear()
-    ch := "b"
-    ch := "c"
+    ch := Some("b")
+    ch := Some("c")
 
     assertEquals(elems, mutable.ArrayBuffer(1, 0, 1, 2))
   }
@@ -64,11 +64,11 @@ object OptTest extends SimpleTestSuite {
     val elems = mutable.ArrayBuffer.empty[Option[Int]]
 
     val ch = Opt[Int]()
-    ch.values.attach(elems += _)
+    ch.attach(elems += _)
 
-    ch := 1
+    ch := Some(1)
     ch.clear()
-    ch := 2
+    ch := Some(2)
 
     assertEquals(elems, mutable.ArrayBuffer(None, Some(1), None, Some(2)))
   }

--- a/shared/src/test/scala/org/widok/OptTest.scala
+++ b/shared/src/test/scala/org/widok/OptTest.scala
@@ -28,10 +28,10 @@ object OptTest extends SimpleTestSuite {
 
     x := "a"
 
-    ch := Some(1)
+    ch := 1
     x := "b"
 
-    ch := Some(2)
+    ch := 2
     x := "c"
 
     assertEquals(elems, mutable.ArrayBuffer("a0", "b1", "c2"))
@@ -54,8 +54,8 @@ object OptTest extends SimpleTestSuite {
     size.attach(elems += _)
 
     ch.clear()
-    ch := Some("b")
-    ch := Some("c")
+    ch := "b"
+    ch := "c"
 
     assertEquals(elems, mutable.ArrayBuffer(1, 0, 1, 2))
   }
@@ -66,9 +66,9 @@ object OptTest extends SimpleTestSuite {
     val ch = Opt[Int]()
     ch.attach(elems += _)
 
-    ch := Some(1)
+    ch := 1
     ch.clear()
-    ch := Some(2)
+    ch := 2
 
     assertEquals(elems, mutable.ArrayBuffer(None, Some(1), None, Some(2)))
   }


### PR DESCRIPTION
See #75 for the whole discussion.

The only reason I haven't merged it yet is that setting a value on an ``Opt`` becomes slightly inconvenient: ``opt := Some(value)`` instead of ``opt := value``. ``:=`` cannot be overloaded with ``Option[T]`` unfortunately. I'd like to refrain from adding a second operator.